### PR TITLE
Checking node version for use correct number of tx bytes

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,20 @@
+export function cmpVersion(targetVersion: string, comparingVersion: string): Number {
+  const regExStrip0 = /(\.0+)+$/
+  const segmentsA = targetVersion.replace(regExStrip0, '').split('.')
+  const segmentsB = comparingVersion.replace(regExStrip0, '').split('.')
+  const l = Math.min(segmentsA.length, segmentsB.length)
+
+  let diff
+  for (let i = 0; i < l; i++) {
+    diff = parseInt(segmentsA[i], 10) - parseInt(segmentsB[i], 10)
+    if (diff) {
+      return diff
+    }
+  }
+
+  return segmentsA.length - segmentsB.length
+}
+
+export function versionGreaterThan(targetVersion: string, comparingVersion: string): Boolean {
+  return cmpVersion(targetVersion, comparingVersion) < 0
+}


### PR DESCRIPTION
* Do not rely on `tx_result.info` to deserialize call or deploy
* Check the current version of the node to use the properly bytes size for tx
* Adding utils to check the semantic version
* Comparing the semantic version with `0.22.8` to get the correct tx byte size